### PR TITLE
expose global aws config

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const async = require('async');
+const AWS = require('aws-sdk');
 const decrypter = require('./lib/decrypter');
 const encoder = require('./lib/encoder');
 const hmac = require('./lib/hmac');
@@ -6,12 +7,17 @@ const keys = require('./lib/keys');
 const secrets = require('./lib/secrets');
 const xtend = require('xtend');
 
+if (typeof process.env.AWS_DEFAULT_REGION !== 'undefined') {
+  AWS.config.update({region: process.env.AWS_DEFAULT_REGION});
+}
+
 const defaults = {
   limit: 1
 };
 
 function Credstash(config) {
   this.table = config ? config.table : undefined;
+  this.AWS = AWS;
 }
 
 Credstash.prototype.list = function(options, done) {

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -2,10 +2,6 @@ const AWS = require('aws-sdk');
 const async = require('async');
 const encoder = require('./encoder');
 
-if (typeof process.env.AWS_DEFAULT_REGION !== 'undefined') {
-  AWS.config.update({region: process.env.AWS_DEFAULT_REGION});
-}
-
 function decrypt(key, done) {
   var params = {
     CiphertextBlob: encoder.decode(key)

--- a/lib/secrets.js
+++ b/lib/secrets.js
@@ -1,10 +1,6 @@
 const AWS = require('aws-sdk');
 const async = require('async');
 
-if (typeof process.env.AWS_DEFAULT_REGION !== 'undefined') {
-  AWS.config.update({region: process.env.AWS_DEFAULT_REGION});
-}
-
 // Blatantly borrowed from https://www.electrictoolbox.com/pad-number-zeroes-javascript/
 function pad(number, length) {
   var str = '' + number;


### PR DESCRIPTION
The `AWS.config` object is global, so the `AWS_DEFAULT_REGION` code can be called once in the index. Also, if we expose `credstash.AWS`, consumers can configure the SDK however they like.